### PR TITLE
fix for potential buffer overflow

### DIFF
--- a/macchina/can_handler.cpp
+++ b/macchina/can_handler.cpp
@@ -39,7 +39,7 @@ bool canbus_handler::isFree() {
 // Set a filter on one of the Rx mailboxes
 void canbus_handler::setFilter(uint32_t canid, uint32_t mask, bool isExtended) {
     char buf[40] = {0x00};
-    sprintf(buf, "Setting Rx Filters - MASK: 0x%04X, Filter: 0x%04X", mask, canid);
+    sprintf(buf, "Setting Rx Filters - MASK: 0x%04X, Filter: 0x%04X", mask, canid, len);
     PCCOMM::logToSerial(buf);
     for (int i = 0; i < 7; i++) {
         this->can->setRXFilter(canid, mask, isExtended);

--- a/macchina/handlers.cpp
+++ b/macchina/handlers.cpp
@@ -52,7 +52,7 @@ void handler::add_filter(uint8_t id, uint8_t type, uint32_t mask, uint32_t filte
         resp
     };
     char buf[100] = {0x00};
-    sprintf(buf, "Setting filter. Type: %02X, Mask: %04X, Filter: %04X, Resp: %04X", type, mask, filter, resp);
+    sprintf(buf, "Setting filter. Type: %02X, Mask: %04X, Filter: %04X, Resp: %04X", type, mask, filter, resp, len);
     PCCOMM::logToSerial(buf);
 }
 


### PR DESCRIPTION
The buffer being copied to is not large enough, or checked, to hold the data being copied to it. This could be result in a buffer overflow